### PR TITLE
chore: changes for latest river api

### DIFF
--- a/ixai/utils/validators/loss.py
+++ b/ixai/utils/validators/loss.py
@@ -10,12 +10,14 @@ from ixai.utils.wrappers.river import RiverMetricToLossFunction
 
 def _get_loss_function_from_river_metric(river_metric: "Metric"):
     try:
-        _ = river_metric.update(y_true=0, y_pred=0).revert(y_true=0, y_pred=0)
+        _ = river_metric.update(y_true=0, y_pred=0)
+        _ = river_metric.revert(y_true=0, y_pred=0)
         validated_loss_function = RiverMetricToLossFunction(river_metric=river_metric, dict_input_metric=False)
         _ = validated_loss_function(0, {'output': 0})
         return validated_loss_function
     except AttributeError:  # river metric expects a dict as y_pred
-        _ = river_metric.update(y_true=0, y_pred={0: 0}).revert(y_true=0, y_pred={0: 0})
+        _ = river_metric.update(y_true=0, y_pred={0: 0})
+        _ = river_metric.revert(y_true=0, y_pred={0: 0})
         validated_loss_function = RiverMetricToLossFunction(river_metric=river_metric, dict_input_metric=True)
         _ = validated_loss_function(0, {'output_1': 0})
         return validated_loss_function

--- a/ixai/utils/wrappers/river.py
+++ b/ixai/utils/wrappers/river.py
@@ -85,6 +85,7 @@ class RiverMetricToLossFunction:
         """
         if not self._dict_input_metric:
             y_prediction = y_prediction.get('output', 0)
-        loss_i = self._river_metric.update(y_true=y_true, y_pred=y_prediction).get()
+        _ = self._river_metric.update(y_true=y_true, y_pred=y_prediction)
+        loss_i = self._river_metric.get()
         self._river_metric.revert(y_true=y_true, y_pred=y_prediction)
         return loss_i * self._sign


### PR DESCRIPTION
River metrics don't return the metric object anymore as per a recent breaking API change. This should make iXAI compatible with the latest river version. 